### PR TITLE
Merge upstream 2.0.12 to circuitpython; fix to use new I2C driver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        idf_ver: ["release-v4.4", "release-v5.0", "release-v5.1", "release-v5.2", "latest"]
+        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "latest"]
         idf_target: ["esp32", "esp32s2", "esp32s3", "esp32c2", "esp32c3"]
-        exclude:
-          - idf_ver: "release-v4.4"
-            idf_target: esp32c2 # ESP32C2 support started with version 5.0
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "latest"]
+        idf_ver: ["release-v5.3", "latest"]
         idf_target: ["esp32", "esp32s2", "esp32s3", "esp32c2", "esp32c3"]
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:

--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: Upload component to the component registry
-        uses: espressif/github-actions/upload_components@master
+        uses: espressif/upload-components-ci-action@v1
         with:
           name: "esp32-camera"
           namespace: "espressif"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET ST
   list(APPEND srcs
     driver/esp_camera.c
     driver/cam_hal.c
-    driver/sccb.c
     driver/sensor.c
     sensors/ov2640.c
     sensors/ov3660.c
@@ -80,6 +79,15 @@ if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET ST
   set(min_version_for_esp_timer "4.2")
   if (idf_version VERSION_GREATER_EQUAL min_version_for_esp_timer)
     list(APPEND priv_requires esp_timer)
+  endif()
+
+  # include the SCCB I2C driver
+  # this uses either the legacy I2C API or the newwer version from IDF v5.4
+  # as this features a method to obtain the I2C driver from a port number
+  if (idf_version VERSION_GREATER_EQUAL "5.4")
+    list(APPEND srcs driver/sccb-ng.c)
+  else()
+    list(APPEND srcs driver/sccb.c)
   endif()
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,16 +84,19 @@ if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET ST
   # include the SCCB I2C driver
   # this uses either the legacy I2C API or the newwer version from IDF v5.4
   # as this features a method to obtain the I2C driver from a port number
-  if (idf_version VERSION_GREATER_EQUAL "5.4")
-    list(APPEND srcs driver/sccb-ng.c)
-  else()
-    list(APPEND srcs driver/sccb.c)
-  endif()
+  # CIRCUITPY-CHANGE: always use new I2C driver. Remove this after updating to ESP-IDF v5.4.
+  # if (idf_version VERSION_GREATER_EQUAL "5.3")
+  #   list(APPEND srcs driver/sccb-ng.c)
+  # else()
+  #   list(APPEND srcs driver/sccb.c)
+  # endif()
+
+  list(APPEND srcs driver/sccb-ng.c)
 
 endif()
 
 # CONFIG_ESP_ROM_HAS_JPEG_DECODE is available from IDF v4.4 but
-# previous IDF supported chips already support JPEG decoder, hence okay to use this
+# previous IDF supported chips already support JPEG decoder, hence okay qto use this
 if(idf_version VERSION_GREATER_EQUAL "4.4" AND NOT CONFIG_ESP_ROM_HAS_JPEG_DECODE)
   list(APPEND srcs
     target/tjpgd.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET ST
 endif()
 
 # CONFIG_ESP_ROM_HAS_JPEG_DECODE is available from IDF v4.4 but
-# previous IDF supported chips already support JPEG decoder, hence okay qto use this
+# previous IDF supported chips already support JPEG decoder, hence okay to use this
 if(idf_version VERSION_GREATER_EQUAL "4.4" AND NOT CONFIG_ESP_ROM_HAS_JPEG_DECODE)
   list(APPEND srcs
     target/tjpgd.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,14 +84,12 @@ if(IDF_TARGET STREQUAL "esp32" OR IDF_TARGET STREQUAL "esp32s2" OR IDF_TARGET ST
   # include the SCCB I2C driver
   # this uses either the legacy I2C API or the newwer version from IDF v5.4
   # as this features a method to obtain the I2C driver from a port number
-  # CIRCUITPY-CHANGE: always use new I2C driver. Remove this after updating to ESP-IDF v5.4.
-  # if (idf_version VERSION_GREATER_EQUAL "5.3")
-  #   list(APPEND srcs driver/sccb-ng.c)
-  # else()
-  #   list(APPEND srcs driver/sccb.c)
-  # endif()
-
-  list(APPEND srcs driver/sccb-ng.c)
+  # CIRCUITPY-CHANGE: Use new driver for 5.3 or greater.
+  if (idf_version VERSION_GREATER_EQUAL "5.3")
+    list(APPEND srcs driver/sccb-ng.c)
+  else()
+    list(APPEND srcs driver/sccb.c)
+  endif()
 
 endif()
 

--- a/Kconfig
+++ b/Kconfig
@@ -179,6 +179,33 @@ menu "Camera configuration"
             Maximum value of DMA buffer
             Larger values may fail to allocate due to insufficient contiguous memory blocks, and smaller value may cause DMA interrupt to be too frequent.
 
+    choice CAMERA_JPEG_MODE_FRAME_SIZE_OPTION
+        prompt "JPEG mode frame size option"
+        default CAMERA_JPEG_MODE_FRAME_SIZE_AUTO
+        help
+            Select whether to use automatic calculation for JPEG mode frame size or specify a custom value.
+
+        config CAMERA_JPEG_MODE_FRAME_SIZE_AUTO
+            bool "Use automatic calculation (width * height / 5)"
+            help
+                Use the default calculation for JPEG mode frame size.
+                Note: In very low resolutions like QQVGA, the default calculation tends to result in insufficient buffer size.
+
+        config CAMERA_JPEG_MODE_FRAME_SIZE_CUSTOM
+            bool "Specify custom frame size"
+            help
+                Specify a custom frame size in bytes for JPEG mode.
+
+    endchoice
+
+    config CAMERA_JPEG_MODE_FRAME_SIZE
+        int "Custom JPEG mode frame size (bytes)"
+        default 8192
+        depends on CAMERA_JPEG_MODE_FRAME_SIZE_CUSTOM
+        help
+            This option sets the custom frame size in JPEG mode.
+            Specify the desired buffer size in bytes.
+
     config CAMERA_CONVERTER_ENABLED
         bool "Enable camera RGB/YUV converter"
         depends on IDF_TARGET_ESP32S3

--- a/driver/cam_hal.c
+++ b/driver/cam_hal.c
@@ -374,7 +374,11 @@ esp_err_t cam_config(const camera_config_t *config, framesize_t frame_size, uint
     cam_obj->height = resolution[frame_size].height;
 
     if(cam_obj->jpeg_mode){
+#ifdef CONFIG_CAMERA_JPEG_MODE_FRAME_SIZE_AUTO
         cam_obj->recv_size = cam_obj->width * cam_obj->height / 5;
+#else
+        cam_obj->recv_size = CONFIG_CAMERA_JPEG_MODE_FRAME_SIZE;
+#endif
         cam_obj->fb_size = cam_obj->recv_size;
     } else {
         cam_obj->recv_size = cam_obj->width * cam_obj->height * cam_obj->in_bytes_per_pixel;

--- a/driver/esp_camera.c
+++ b/driver/esp_camera.c
@@ -153,7 +153,7 @@ static esp_err_t camera_probe(const camera_config_t *config, camera_model_t *out
         return ESP_ERR_INVALID_STATE;
     }
 
-    s_state = (camera_state_t *) calloc(sizeof(camera_state_t), 1);
+    s_state = (camera_state_t *) calloc(1, sizeof(camera_state_t));
     if (!s_state) {
         return ESP_ERR_NO_MEM;
     }

--- a/driver/esp_camera.c
+++ b/driver/esp_camera.c
@@ -168,7 +168,8 @@ static esp_err_t camera_probe(const camera_config_t *config, camera_model_t *out
         ret = SCCB_Init(config->pin_sccb_sda, config->pin_sccb_scl);
     } else {
         ESP_LOGD(TAG, "Using existing I2C port");
-        ret = SCCB_Use_Port(config->sccb_i2c_port);
+        // CIRCUITPY-CHANGE: pass in bus handle. Remove after update to ESP-IDF v5.4.
+        ret = SCCB_Use_Port(config->sccb_i2c_port, config->sccb_i2c_master_bus_handle);
     }
 
     if(ret != ESP_OK) {
@@ -494,4 +495,3 @@ void esp_camera_return_all(void) {
     }
     cam_give_all();
 }
-

--- a/driver/esp_camera.c
+++ b/driver/esp_camera.c
@@ -163,13 +163,15 @@ static esp_err_t camera_probe(const camera_config_t *config, camera_model_t *out
         CAMERA_ENABLE_OUT_CLOCK(config);
     }
 
-    if (config->pin_sccb_sda != -1) {
-        ESP_LOGD(TAG, "Initializing SCCB");
-        ret = SCCB_Init(config->pin_sccb_sda, config->pin_sccb_scl);
-    } else {
+    // CIRCUITPY-CHANGE: use passed-in handle; never initialize with pins
+    // if (config->pin_sccb_sda != -1) {
+    //     ESP_LOGD(TAG, "Initializing SCCB");
+    //     ret = SCCB_Init(config->pin_sccb_sda, config->pin_sccb_scl);
+    // } else {
+    {
         ESP_LOGD(TAG, "Using existing I2C port");
-        // CIRCUITPY-CHANGE: pass in bus handle. Remove after update to ESP-IDF v5.4.
-        ret = SCCB_Use_Port(config->sccb_i2c_port, config->sccb_i2c_master_bus_handle);
+        // CIRCUITPY-CHANGE: pass in bus handle.
+        ret = SCCB_Use_Handle(config->sccb_i2c_master_bus_handle);
     }
 
     if(ret != ESP_OK) {

--- a/driver/include/esp_camera.h
+++ b/driver/include/esp_camera.h
@@ -157,8 +157,8 @@ typedef struct {
     camera_conv_mode_t conv_mode;   /*!< RGB<->YUV Conversion mode */
 #endif
 
-    int sccb_i2c_port;              /*!< If pin_sccb_sda is -1, use the already configured I2C bus by number */
-    // CIRCUITPY-CHANGE: Pass in handle to config. Remove after update to ESP-IDF v5.4.
+    // CIRCUITPY-CHANGE: use handle instead of port, because it's owned by CircuitPython
+    // int sccb_i2c_port;              /*!< If pin_sccb_sda is -1, use the already configured I2C bus by number */
     i2c_master_bus_handle_t sccb_i2c_master_bus_handle;
 } camera_config_t;
 

--- a/driver/include/esp_camera.h
+++ b/driver/include/esp_camera.h
@@ -72,6 +72,9 @@
 #include "sys/time.h"
 #include "sdkconfig.h"
 
+// CIRCUITPY-CHANGE. Remove after updating to ESP-IDF v5.4.
+#include "driver/i2c_types.h"
+
 /**
  * @brief define for if chip supports camera
  */
@@ -155,6 +158,8 @@ typedef struct {
 #endif
 
     int sccb_i2c_port;              /*!< If pin_sccb_sda is -1, use the already configured I2C bus by number */
+    // CIRCUITPY-CHANGE: Pass in handle to config. Remove after update to ESP-IDF v5.4.
+    i2c_master_bus_handle_t sccb_i2c_master_bus_handle;
 } camera_config_t;
 
 /**

--- a/driver/private_include/sccb.h
+++ b/driver/private_include/sccb.h
@@ -9,11 +9,11 @@
 #ifndef __SCCB_H__
 #define __SCCB_H__
 #include <stdint.h>
-// CIRCUITPY-CHANGE: need i2c_master_bus_handle_t. Remove after updating to ESP-IDF v5.4.
+// CIRCUITPY-CHANGE: need i2c_master_bus_handle_t
 #include "driver/i2c_types.h"
 int SCCB_Init(int pin_sda, int pin_scl);
-// CIRCUITPY-CHANGE: pass in handle as an extra argument. Remove extra arg after update to ESP-IDF v5.4.
-int SCCB_Use_Port(int i2c_num, i2c_master_bus_handle_t handle);
+// CIRCUITPY-CHANGE: pass handle instead of port
+int SCCB_Use_Handle(i2c_master_bus_handle_t handle);
 int SCCB_Deinit(void);
 uint8_t SCCB_Probe(void);
 uint8_t SCCB_Read(uint8_t slv_addr, uint8_t reg);

--- a/driver/private_include/sccb.h
+++ b/driver/private_include/sccb.h
@@ -9,8 +9,11 @@
 #ifndef __SCCB_H__
 #define __SCCB_H__
 #include <stdint.h>
+// CIRCUITPY-CHANGE: need i2c_master_bus_handle_t. Remove after updating to ESP-IDF v5.4.
+#include "driver/i2c_types.h"
 int SCCB_Init(int pin_sda, int pin_scl);
-int SCCB_Use_Port(int sccb_i2c_port);
+// CIRCUITPY-CHANGE: pass in handle as an extra argument. Remove extra arg after update to ESP-IDF v5.4.
+int SCCB_Use_Port(int i2c_num, i2c_master_bus_handle_t handle);
 int SCCB_Deinit(void);
 uint8_t SCCB_Probe(void);
 uint8_t SCCB_Read(uint8_t slv_addr, uint8_t reg);

--- a/driver/sccb-ng.c
+++ b/driver/sccb-ng.c
@@ -1,0 +1,358 @@
+/*
+ * This file is part of the OpenMV project.
+ * Copyright (c) 2013/2014 Ibrahim Abdelkader <i.abdalkader@gmail.com>
+ * This work is licensed under the MIT license, see the file LICENSE for details.
+ *
+ * SCCB (I2C like) driver with the new esp-idf I2C API.
+ *
+ */
+#include <stdbool.h>
+#include <string.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include "sccb.h"
+#include "sensor.h"
+#include <stdio.h>
+#include "sdkconfig.h"
+#if defined(ARDUINO_ARCH_ESP32) && defined(CONFIG_ARDUHAL_ESP_LOG)
+#include "esp32-hal-log.h"
+#else
+#include "esp_log.h"
+static const char *TAG = "sccb-ng";
+#endif
+
+#define LITTLETOBIG(x) ((x << 8) | (x >> 8))
+
+#include "esp_private/i2c_platform.h"
+#include "driver/i2c_master.h"
+#include "driver/i2c_types.h"
+
+// support IDF 5.x
+#ifndef portTICK_RATE_MS
+#define portTICK_RATE_MS portTICK_PERIOD_MS
+#endif
+
+#define TIMEOUT_MS 1000                /*!< I2C timeout duration */
+#define SCCB_FREQ CONFIG_SCCB_CLK_FREQ /*!< I2C master frequency */
+#define WRITE_BIT I2C_MASTER_WRITE     /*!< I2C master write */
+#define READ_BIT I2C_MASTER_READ       /*!< I2C master read */
+#define ACK_CHECK_EN 0x1               /*!< I2C master will check ack from slave */
+#define ACK_CHECK_DIS 0x0              /*!< I2C master will not check ack from slave */
+#define ACK_VAL 0x0                    /*!< I2C ack value */
+#define NACK_VAL 0x1                   /*!< I2C nack value */
+#if CONFIG_SCCB_HARDWARE_I2C_PORT1
+const int SCCB_I2C_PORT_DEFAULT = 1;
+#else
+const int SCCB_I2C_PORT_DEFAULT = 0;
+#endif
+
+#define MAX_DEVICES UINT8_MAX-1
+
+/*
+ The legacy I2C driver used addresses to differentiate between devices, whereas the new driver uses
+ i2c_master_dev_handle_t structs which are registed to the bus.
+ To avoid re-writing all camera dependant code, we simply translate the devices address to the corresponding
+ device_handle. This keeps all interfaces to the drivers identical.
+ To perform this conversion the following local struct is used.
+*/
+typedef struct
+{
+    i2c_master_dev_handle_t dev_handle;
+    uint16_t address;
+} device_t;
+
+static device_t devices[MAX_DEVICES];
+static uint8_t device_count = 0;
+static int sccb_i2c_port;
+static bool sccb_owns_i2c_port;
+
+i2c_master_dev_handle_t *get_handle_from_address(uint8_t slv_addr)
+{
+    for (uint8_t i = 0; i < device_count; i++)
+    {
+
+        if (slv_addr == devices[i].address)
+        {
+            return &(devices[i].dev_handle);
+        }
+    }
+
+    ESP_LOGE(TAG, "Device with address %02x not found", slv_addr);
+    return NULL;
+}
+
+int SCCB_Install_Device(uint8_t slv_addr)
+{
+    esp_err_t ret;
+    i2c_master_bus_handle_t bus_handle;
+
+    if (device_count > MAX_DEVICES)
+    {
+        ESP_LOGE(TAG, "cannot add more than %d devices", MAX_DEVICES);
+        return ESP_FAIL;
+    }
+
+    ret = i2c_master_get_bus_handle(sccb_i2c_port, &bus_handle);
+    if (ret != ESP_OK)
+    {
+        ESP_LOGE(TAG, "failed to get SCCB I2C Bus handle for port %d", sccb_i2c_port);
+        return ret;
+    }
+
+    i2c_device_config_t dev_cfg = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = slv_addr, // not yet set
+        .scl_speed_hz = SCCB_FREQ,
+    };
+
+    ret = i2c_master_bus_add_device(bus_handle, &dev_cfg, &(devices[device_count].dev_handle));
+    if (ret != ESP_OK)
+    {
+        ESP_LOGE(TAG, "failed to install SCCB I2C device: %s", esp_err_to_name(ret));
+        return -1;
+    }
+
+    devices[device_count].address = slv_addr;
+    device_count++;
+    return 0;
+}
+
+int SCCB_Init(int pin_sda, int pin_scl)
+{
+    ESP_LOGI(TAG, "pin_sda %d pin_scl %d", pin_sda, pin_scl);
+    // i2c_config_t conf;
+    esp_err_t ret;
+
+    sccb_i2c_port = SCCB_I2C_PORT_DEFAULT;
+    sccb_owns_i2c_port = true;
+    ESP_LOGI(TAG, "sccb_i2c_port=%d", sccb_i2c_port);
+
+    i2c_master_bus_config_t i2c_mst_config = {
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .i2c_port = SCCB_I2C_PORT_DEFAULT,
+        .scl_io_num = pin_scl,
+        .sda_io_num = pin_sda,
+        .glitch_ignore_cnt = 7,
+        .flags.enable_internal_pullup = 1};
+
+    i2c_master_bus_handle_t bus_handle;
+    ret = i2c_new_master_bus(&i2c_mst_config, &bus_handle);
+
+    if (ret != ESP_OK)
+    {
+        ESP_LOGE(TAG, "failed to install SCCB I2C master bus on port %d: %s", sccb_i2c_port, esp_err_to_name(ret));
+        return ret;
+    }
+
+    return ESP_OK;
+}
+
+int SCCB_Use_Port(int i2c_num)
+{ // sccb use an already initialized I2C port
+    if (sccb_owns_i2c_port)
+    {
+        SCCB_Deinit();
+    }
+    if (i2c_num < 0 || i2c_num > I2C_NUM_MAX)
+    {
+        return ESP_ERR_INVALID_ARG;
+    }
+    sccb_i2c_port = i2c_num;
+
+    return ESP_OK;
+}
+
+int SCCB_Deinit(void)
+{
+    esp_err_t ret;
+
+    for (uint8_t i = 0; i < device_count; i++)
+    {
+        ret = i2c_master_bus_rm_device(devices[i].dev_handle);
+        if (ret != ESP_OK)
+        {
+            ESP_LOGE(TAG, "failed to remove SCCB I2C Device");
+            return ret;
+        }
+
+        devices[i].dev_handle = NULL;
+        devices[i].address = 0;
+    }
+    device_count = 0;
+
+    if (!sccb_owns_i2c_port)
+    {
+        return ESP_OK;
+    }
+    sccb_owns_i2c_port = false;
+
+    i2c_master_bus_handle_t bus_handle;
+    ret = i2c_master_get_bus_handle(sccb_i2c_port, &bus_handle);
+    if (ret != ESP_OK)
+    {
+        ESP_LOGE(TAG, "failed to get SCCB I2C Bus handle for port %d", sccb_i2c_port);
+        return ret;
+    }
+
+    ret = i2c_del_master_bus(bus_handle);
+    if (ret != ESP_OK)
+    {
+        ESP_LOGE(TAG, "failed to get delete SCCB I2C Master Bus at port %d", sccb_i2c_port);
+        return ret;
+    }
+
+    return ESP_OK;
+}
+
+uint8_t SCCB_Probe(void)
+{
+    uint8_t slave_addr = 0x0;
+    esp_err_t ret;
+    i2c_master_bus_handle_t bus_handle;
+
+    ret = i2c_master_get_bus_handle(sccb_i2c_port, &bus_handle);
+    if (ret != ESP_OK)
+    {
+        ESP_LOGE(TAG, "failed to get SCCB I2C Bus handle for port %d", sccb_i2c_port);
+        return ret;
+    }
+
+    for (size_t i = 0; i < CAMERA_MODEL_MAX; i++)
+    {
+        if (slave_addr == camera_sensor[i].sccb_addr)
+        {
+            continue;
+        }
+        slave_addr = camera_sensor[i].sccb_addr;
+
+        ret = i2c_master_probe(bus_handle, slave_addr, TIMEOUT_MS);
+
+        if (ret == ESP_OK)
+        {
+            if (SCCB_Install_Device(slave_addr) != 0)
+            {
+                return 0;
+            }
+            return slave_addr;
+        }
+    }
+    return 0;
+}
+
+uint8_t SCCB_Read(uint8_t slv_addr, uint8_t reg)
+{
+    i2c_master_dev_handle_t dev_handle = *(get_handle_from_address(slv_addr));
+
+    uint8_t tx_buffer[1];
+    uint8_t rx_buffer[1];
+
+    tx_buffer[0] = reg;
+
+    esp_err_t ret = i2c_master_transmit_receive(dev_handle, tx_buffer, 1, rx_buffer, 1, TIMEOUT_MS);
+
+    if (ret != ESP_OK)
+    {
+        ESP_LOGE(TAG, "SCCB_Read Failed addr:0x%02x, reg:0x%02x, data:0x%02x, ret:%d", slv_addr, reg, rx_buffer[0], ret);
+    }
+
+    return rx_buffer[0];
+}
+
+int SCCB_Write(uint8_t slv_addr, uint8_t reg, uint8_t data)
+{
+    i2c_master_dev_handle_t dev_handle = *(get_handle_from_address(slv_addr));
+
+    uint8_t tx_buffer[2];
+    tx_buffer[0] = reg;
+    tx_buffer[1] = data;
+
+    esp_err_t ret = i2c_master_transmit(dev_handle, tx_buffer, 2, TIMEOUT_MS);
+
+    if (ret != ESP_OK)
+    {
+        ESP_LOGE(TAG, "SCCB_Write Failed addr:0x%02x, reg:0x%02x, data:0x%02x, ret:%d", slv_addr, reg, data, ret);
+    }
+
+    return ret == ESP_OK ? 0 : -1;
+}
+
+uint8_t SCCB_Read16(uint8_t slv_addr, uint16_t reg)
+{
+    i2c_master_dev_handle_t dev_handle = *(get_handle_from_address(slv_addr));
+
+    uint8_t rx_buffer[1];
+
+    uint16_t reg_htons = LITTLETOBIG(reg);
+    uint8_t *reg_u8 = (uint8_t *)&reg_htons;
+
+    esp_err_t ret = i2c_master_transmit_receive(dev_handle, reg_u8, 2, rx_buffer, 1, TIMEOUT_MS);
+
+    if (ret != ESP_OK)
+    {
+        ESP_LOGE(TAG, "W [%04x]=%02x fail\n", reg, rx_buffer[0]);
+    }
+
+    return rx_buffer[0];
+}
+
+int SCCB_Write16(uint8_t slv_addr, uint16_t reg, uint8_t data)
+{
+    i2c_master_dev_handle_t dev_handle = *(get_handle_from_address(slv_addr));
+
+    uint16_t reg_htons = LITTLETOBIG(reg);
+
+    uint8_t tx_buffer[3];
+    tx_buffer[0] = reg_htons >> 8;
+    tx_buffer[1] = reg_htons & 0x00ff;
+    tx_buffer[2] = data;
+
+    esp_err_t ret = i2c_master_transmit(dev_handle, tx_buffer, 3, TIMEOUT_MS);
+
+    if (ret != ESP_OK)
+    {
+        ESP_LOGE(TAG, "W [%04x]=%02x fail\n", reg, data);
+    }
+    return ret == ESP_OK ? 0 : -1;
+}
+
+uint16_t SCCB_Read_Addr16_Val16(uint8_t slv_addr, uint16_t reg)
+{
+    i2c_master_dev_handle_t dev_handle = *(get_handle_from_address(slv_addr));
+
+    uint8_t rx_buffer[2];
+
+    uint16_t reg_htons = LITTLETOBIG(reg);
+    uint8_t *reg_u8 = (uint8_t *)&reg_htons;
+
+    esp_err_t ret = i2c_master_transmit_receive(dev_handle, reg_u8, 2, rx_buffer, 2, TIMEOUT_MS);
+    uint16_t data = ((uint16_t)rx_buffer[0] << 8) | (uint16_t)rx_buffer[1];
+
+    if (ret != ESP_OK)
+    {
+        ESP_LOGE(TAG, "W [%04x]=%02x fail\n", reg, data);
+    }
+
+    return data;
+}
+
+int SCCB_Write_Addr16_Val16(uint8_t slv_addr, uint16_t reg, uint16_t data)
+{
+    i2c_master_dev_handle_t dev_handle = *(get_handle_from_address(slv_addr));
+
+    uint16_t reg_htons = LITTLETOBIG(reg);
+
+    uint8_t tx_buffer[4];
+    tx_buffer[0] = reg_htons >> 8;
+    tx_buffer[1] = reg_htons & 0x00ff;
+    tx_buffer[2] = data >> 8;
+    tx_buffer[3] = data & 0x00ff;
+
+    esp_err_t ret = i2c_master_transmit(dev_handle, tx_buffer, 4, TIMEOUT_MS);
+
+    if (ret != ESP_OK)
+    {
+        ESP_LOGE(TAG, "W [%04x]=%02x fail\n", reg, data);
+    }
+    return ret == ESP_OK ? 0 : -1;
+    return 0;
+}

--- a/driver/sccb-ng.c
+++ b/driver/sccb-ng.c
@@ -35,12 +35,6 @@ static const char *TAG = "sccb-ng";
 
 #define TIMEOUT_MS 1000                /*!< I2C timeout duration */
 #define SCCB_FREQ CONFIG_SCCB_CLK_FREQ /*!< I2C master frequency */
-#define WRITE_BIT I2C_MASTER_WRITE     /*!< I2C master write */
-#define READ_BIT I2C_MASTER_READ       /*!< I2C master read */
-#define ACK_CHECK_EN 0x1               /*!< I2C master will check ack from slave */
-#define ACK_CHECK_DIS 0x0              /*!< I2C master will not check ack from slave */
-#define ACK_VAL 0x0                    /*!< I2C ack value */
-#define NACK_VAL 0x1                   /*!< I2C nack value */
 #if CONFIG_SCCB_HARDWARE_I2C_PORT1
 const int SCCB_I2C_PORT_DEFAULT = 1;
 #else
@@ -62,12 +56,22 @@ static esp_err_t register_device(uint8_t device_addr, i2c_master_dev_handle_t *d
         .scl_speed_hz = SCCB_FREQ,
     };
 
-    return i2c_master_bus_add_device(sccb_i2c_master_bus_handle, &dev_config, dev_handle);
+    esp_err_t ret = i2c_master_bus_add_device(sccb_i2c_master_bus_handle, &dev_config, dev_handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "register_device failed bus_handle:%p, slv_addr: 0x%02x, ret:%d", sccb_i2c_master_bus_handle, device_addr, ret);
+    }
+
+    return ret;
 }
 
 static esp_err_t deregister_device(i2c_master_dev_handle_t dev_handle)
 {
-    return i2c_master_bus_rm_device(dev_handle);
+    esp_err_t ret = i2c_master_bus_rm_device(dev_handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "deregister_device failed ret:%d", ret);
+    }
+
+    return ret;
 }
 
 int SCCB_Install_Device(uint8_t slv_addr)
@@ -200,11 +204,9 @@ int SCCB_Write16(uint8_t slv_addr, uint16_t reg, uint8_t data)
 {
     // CIRCUITPY-CHANGE: register device only while in use
 
-    uint16_t reg_htons = LITTLETOBIG(reg);
-
     uint8_t tx_buffer[3];
-    tx_buffer[0] = reg_htons >> 8;
-    tx_buffer[1] = reg_htons & 0x00ff;
+    tx_buffer[0] = reg >> 8;
+    tx_buffer[1] = reg & 0x00ff;
     tx_buffer[2] = data;
 
     esp_err_t ret;
@@ -250,11 +252,9 @@ int SCCB_Write_Addr16_Val16(uint8_t slv_addr, uint16_t reg, uint16_t data)
 {
     // CIRCUITPY-CHANGE: register device only while in use
 
-    uint16_t reg_htons = LITTLETOBIG(reg);
-
     uint8_t tx_buffer[4];
-    tx_buffer[0] = reg_htons >> 8;
-    tx_buffer[1] = reg_htons & 0x00ff;
+    tx_buffer[0] = reg >> 8;
+    tx_buffer[1] = reg & 0x00ff;
     tx_buffer[2] = data >> 8;
     tx_buffer[3] = data & 0x00ff;
 
@@ -270,5 +270,4 @@ int SCCB_Write_Addr16_Val16(uint8_t slv_addr, uint16_t reg, uint16_t data)
         ESP_LOGE(TAG, "W [%04x]=%02x fail\n", reg, data);
     }
     return ret == ESP_OK ? 0 : -1;
-    return 0;
 }

--- a/driver/sccb-ng.c
+++ b/driver/sccb-ng.c
@@ -58,7 +58,7 @@ static esp_err_t register_device(uint8_t device_addr, i2c_master_dev_handle_t *d
 
     esp_err_t ret = i2c_master_bus_add_device(sccb_i2c_master_bus_handle, &dev_config, dev_handle);
     if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "register_device failed bus_handle:%p, slv_addr: 0x%02x, ret:%d", sccb_i2c_master_bus_handle, device_addr, ret);
+        ESP_LOGE(TAG, "register_device failed bus_handle:%p, device_addr: 0x%02x, ret:%d", sccb_i2c_master_bus_handle, device_addr, ret);
     }
 
     return ret;
@@ -78,7 +78,7 @@ static esp_err_t i2c_transmit_with_addr(uint8_t device_addr, const uint8_t *writ
     esp_err_t ret;
     i2c_master_dev_handle_t dev_handle = NULL;
 
-    ret = register_device(slv_addr, &dev_handle);
+    ret = register_device(device_addr, &dev_handle);
     if (ret != ESP_OK) {
         return ret;
     }
@@ -92,7 +92,7 @@ static esp_err_t i2c_transmit_receive_with_addr(uint8_t device_addr, const uint8
     esp_err_t ret;
     i2c_master_dev_handle_t dev_handle = NULL;
 
-    ret = register_device(slv_addr, &dev_handle);
+    ret = register_device(device_addr, &dev_handle);
     if (ret != ESP_OK) {
         return ret;
     }
@@ -103,7 +103,7 @@ static esp_err_t i2c_transmit_receive_with_addr(uint8_t device_addr, const uint8
 }
 
 
-int SCCB_Install_Device(uint8_t slv_addr)
+int SCCB_Install_Device(uint8_t device_addr)
 {
     // CIRCUITPY-CHANGE: don't install device: each read or write will do that temporarily,
     return 0;
@@ -185,7 +185,7 @@ int SCCB_Write(uint8_t slv_addr, uint8_t reg, uint8_t data)
     tx_buffer[0] = reg;
     tx_buffer[1] = data;
 
-    esp_err_t ret = i2c_transmit_with_addr(dev_handle, tx_buffer, 2, TIMEOUT_MS);
+    esp_err_t ret = i2c_transmit_with_addr(slv_addr, tx_buffer, 2, TIMEOUT_MS);
 
     if (ret != ESP_OK)
     {
@@ -204,7 +204,7 @@ uint8_t SCCB_Read16(uint8_t slv_addr, uint16_t reg)
     uint16_t reg_htons = LITTLETOBIG(reg);
     uint8_t *reg_u8 = (uint8_t *)&reg_htons;
 
-    esp_err_t ret = i2c_transmit_receive_with_addr(dev_handle, reg_u8, 2, rx_buffer, 1, TIMEOUT_MS);
+    esp_err_t ret = i2c_transmit_receive_with_addr(slv_addr, reg_u8, 2, rx_buffer, 1, TIMEOUT_MS);
 
     if (ret != ESP_OK)
     {
@@ -223,7 +223,7 @@ int SCCB_Write16(uint8_t slv_addr, uint16_t reg, uint8_t data)
     tx_buffer[1] = reg & 0x00ff;
     tx_buffer[2] = data;
 
-    esp_err_t ret = i2c_transmit_with_addr(dev_handle, tx_buffer, 3, TIMEOUT_MS);
+    esp_err_t ret = i2c_transmit_with_addr(slv_addr, tx_buffer, 3, TIMEOUT_MS);
 
     if (ret != ESP_OK)
     {
@@ -241,7 +241,7 @@ uint16_t SCCB_Read_Addr16_Val16(uint8_t slv_addr, uint16_t reg)
     uint16_t reg_htons = LITTLETOBIG(reg);
     uint8_t *reg_u8 = (uint8_t *)&reg_htons;
 
-    esp_err_t ret = i2c_transmit_receive_with_addr(dev_handle, reg_u8, 2, rx_buffer, 2, TIMEOUT_MS);
+    esp_err_t ret = i2c_transmit_receive_with_addr(slv_addr, reg_u8, 2, rx_buffer, 2, TIMEOUT_MS);
     uint16_t data = ((uint16_t)rx_buffer[0] << 8) | (uint16_t)rx_buffer[1];
 
     if (ret != ESP_OK)
@@ -262,7 +262,7 @@ int SCCB_Write_Addr16_Val16(uint8_t slv_addr, uint16_t reg, uint16_t data)
     tx_buffer[2] = data >> 8;
     tx_buffer[3] = data & 0x00ff;
 
-    esp_err_t ret = i2c_transmit_with_addr(dev_handle, tx_buffer, 4, TIMEOUT_MS);
+    esp_err_t ret = i2c_transmit_with_addr(slv_addr, tx_buffer, 4, TIMEOUT_MS);
 
     if (ret != ESP_OK)
     {

--- a/driver/sccb.c
+++ b/driver/sccb.c
@@ -6,6 +6,7 @@
  * SCCB (I2C like) driver.
  *
  */
+
 #include <stdbool.h>
 #include <string.h>
 #include <freertos/FreeRTOS.h>

--- a/target/esp32/ll_cam.c
+++ b/target/esp32/ll_cam.c
@@ -257,7 +257,6 @@ esp_err_t ll_cam_deinit(cam_obj_t *cam)
         esp_intr_free(cam->cam_intr_handle);
         cam->cam_intr_handle = NULL;
     }
-    gpio_uninstall_isr_service();
     return ESP_OK;
 }
 

--- a/target/esp32s2/ll_cam.c
+++ b/target/esp32s2/ll_cam.c
@@ -178,8 +178,6 @@ esp_err_t ll_cam_config(cam_obj_t *cam, const camera_config_t *config)
     I2S0.sample_rate_conf.rx_bck_div_num = 1;
     I2S0.sample_rate_conf.rx_bits_mod = 8;
 
-    I2S0.conf1.rx_pcm_bypass = 1;
-
     I2S0.conf2.i_v_sync_filter_en = 1;
     I2S0.conf2.i_v_sync_filter_thres = 4;
     I2S0.conf2.cam_sync_fifo_reset = 1;

--- a/target/esp32s2/ll_cam.c
+++ b/target/esp32s2/ll_cam.c
@@ -95,7 +95,6 @@ esp_err_t ll_cam_deinit(cam_obj_t *cam)
         esp_intr_free(cam->cam_intr_handle);
         cam->cam_intr_handle = NULL;
     }
-    gpio_uninstall_isr_service();
     return ESP_OK;
 }
 

--- a/target/esp32s3/ll_cam.c
+++ b/target/esp32s3/ll_cam.c
@@ -202,7 +202,11 @@ static esp_err_t ll_cam_dma_init(cam_obj_t *cam)
     gdma_channel_alloc_config_t rx_alloc_config = {
         .direction = GDMA_CHANNEL_DIRECTION_RX,
     };
+#if ((ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR >= 4) || ESP_IDF_VERSION_MAJOR > 5)
+    esp_err_t ret = gdma_new_ahb_channel(&rx_alloc_config, &cam->dma_channel_handle);
+#else
     esp_err_t ret = gdma_new_channel(&rx_alloc_config, &cam->dma_channel_handle);
+#endif
     if (ret != ESP_OK) {
         cam_deinit();
         ESP_LOGE(TAG, "Can't find available GDMA channel");


### PR DESCRIPTION
- Merge upstream version 2.0.12.
- Make changes necessary for new ESP-IDF I2C driver, which will be used in CircuitPython 9.2.0. This includes fixing the bugs described in https://github.com/espressif/esp32-camera/issues/689.

We don't pass around `i2c_master_dev_handle_t` instances when using the new i2C driver. Instead we just create and destroy them on each I2C read/write, `and os sccb-ng.c` had to be reworked to act like `ports/espressif/busio/I2C.c`. In the long run, perhaps this library should be more integrated into CircuitPython.

Also the upstream updates assumed v5.4, which is not out yet.

Tested on Memento with the standard `PyCamera` application. I have a few fixes for the library as well. It takes pictures!